### PR TITLE
Fix dist build

### DIFF
--- a/dune
+++ b/dune
@@ -1,12 +1,12 @@
 (rule
  (alias gobview)
- (targets dist)
- (deps src/App.bc.js node_modules webpack.config.js)
+ (targets (dir dist))
+ (deps src/App.bc.js node_modules webpack.config.js (sandbox always))
  (action
   (run npx webpack build)))
 
 (rule
- (targets node_modules)
- (deps package-lock.json)
+ (targets (dir node_modules))
+ (deps package.json package-lock.json (sandbox always))
  (action
   (run npm ci)))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,5 @@
-(lang dune 2.7)
+(lang dune 3.0)
+(using directory-targets 0.1)
 
 (name gobview)
 

--- a/gobview.opam
+++ b/gobview.opam
@@ -12,7 +12,7 @@ license: "MIT"
 homepage: "https://github.com/goblint/gobview"
 bug-reports: "https://github.com/goblint/gobview/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.0"}
   "ocaml" {>= "4.10.0"}
   "jsoo-react"
   "goblint-cil" {>= "2.0.0"}


### PR DESCRIPTION
Currently `dune build gobview` in Goblint's repository only builds Gobview half-way: it does the js_of_ocaml compilation, but doesn't actually create the `dist` directory that Goblint tries to use with `--enable gobview`.

This doesn't still work because it requires https://github.com/ocaml/dune/issues/5945, which is to be released in dune 3.5.0.