### PR TITLE
 Update for Earlybird usage #1251 

### DIFF
--- a/gobview.opam.locked
+++ b/gobview.opam.locked
@@ -45,9 +45,9 @@ depends: [
   "cstruct" {= "6.1.1"}
   "ctypes_stubs_js" {= "0.1"}
   "domain-name" {= "0.4.0"}
-  "dune" {= "3.6.1"}
-  "dune-build-info" {= "3.6.1"}
-  "dune-configurator" {= "3.6.1"}
+  "dune" {= "3.7.1"}
+  "dune-build-info" {= "3.7.1"}
+  "dune-configurator" {= "3.7.1"}
   "duration" {= "0.2.1"}
   "either" {= "1.0.0"}
   "eqaf" {= "0.9"}


### PR DESCRIPTION
This PR request: 
- Tries to fix the CI issue in  [Update for Earlybird usage #1251 ](https://github.com/goblint/analyzer/pull/1251)
- As of right now, Gobview downgrades the dune dependency back down to 3.6.1. 