### PR TITLE
Add a JavaScript stub for the Goblint specific C stub for pi constant

### DIFF
--- a/runtime/stubs.js
+++ b/runtime/stubs.js
@@ -49,6 +49,12 @@ function smallest_float(x) {
   return 2.2250738585072014e-308;
 }
 
+//Provides: pi
+//from Goblint specific stubs for C float operations
+function pi(x) {
+  return Number.pi;
+}
+
 //external of_int: int -> t
 //Provides: ml_z_of_int const
 //Requires: bigInt


### PR DESCRIPTION
This PR adds the JavaScript stub corresponding to the C stub implemented as part of https://github.com/goblint/analyzer/pull/1277 to improve the approximations of the trigonometric functions.