### PR TITLE
Adapt to removed `Libmaincil` module

### DIFF
--- a/src/App.re
+++ b/src/App.re
@@ -34,6 +34,7 @@ let renumber_goblint_analyses = registered_name => {
 };
 
 let init_goblint = (solver, spec, registered_name, config, cil) => {
+  Cilfacade.init();
   AfterConfig.run(); // This registers the "base" analysis
 
   try(renumber_goblint_analyses(registered_name)) {
@@ -67,7 +68,6 @@ let init_goblint = (solver, spec, registered_name, config, cil) => {
 
   GobConfig.set_auto("trans.activated[+]", "'expeval'");
 
-  Cilfacade.init();
   Maingoblint.handle_extraspecials();
   Maingoblint.handle_flags();
 

--- a/src/dune
+++ b/src/dune
@@ -28,6 +28,7 @@
   yojson
   zarith
   zarith_stubs_js)
+ (flags :standard -linkall)
  (js_of_ocaml
   (javascript_files
    ../runtime/stubs.js


### PR DESCRIPTION
Closes #38 in combination with https://github.com/goblint/cil/pull/165 and https://github.com/goblint/analyzer/pull/1350.