### PR TITLE
Fix file jump

### DIFF
--- a/src/Main.re
+++ b/src/Main.re
@@ -22,7 +22,7 @@ let make = (~cil, ~goblint, ~warnings, ~meta, ~stats, ~file_loc) => {
     )};
 
   let (state, dispatch) = {
-    let file = GvDisplay.File.make(~path=List.hd(mainFiles), ());
+    let file = GvDisplay.File.make(~path=List.hd(mainFiles), ~mode=GvDisplay.C, ());
     React.use_reducer(
       Reducer.reducer,
       ~init=fun () => State.make(~file, ~cil, ~goblint, ~warnings, ~meta, ~stats, ~file_loc, ()),

--- a/src/Main.re
+++ b/src/Main.re
@@ -11,7 +11,7 @@ let make = (~cil, ~goblint, ~warnings, ~meta, ~stats, ~file_loc) => {
       (mainFiles, g) =>
       switch(g) {
       | GFun(fdec, loc) =>
-        if(List.mem(fdec, mf)) {
+        if(List.mem_cmp(CilType.Fundec.compare, fdec, mf)) {
           [loc.file, ...mainFiles]
         } else {
           mainFiles

--- a/src/Main.re
+++ b/src/Main.re
@@ -1,13 +1,32 @@
 open React.Dom.Dsl.Html;
 open Batteries;
+open GoblintCil;
 
 [@react.component]
 let make = (~cil, ~goblint, ~warnings, ~meta, ~stats, ~file_loc) => {
-  let (state, dispatch) =
+  let mainFiles = {
+    let (mf,_,_) = Goblint_lib.Cilfacade.getFuns(cil);
+    Cil.foldGlobals(
+      cil,
+      (mainFiles, g) =>
+      switch(g) {
+      | GFun(fdec, loc) =>
+        if(List.mem(fdec, mf)) {
+          [loc.file, ...mainFiles]
+        } else {
+          mainFiles
+        };
+      | _ => mainFiles
+      },
+      [],
+    )};
+
+  let (state, dispatch) = {
+    let file = GvDisplay.File.make(~path=List.hd(mainFiles), ());
     React.use_reducer(
       Reducer.reducer,
-      ~init=fun () => State.make(~cil, ~goblint, ~warnings, ~meta, ~stats, ~file_loc, ()),
-    );
+      ~init=fun () => State.make(~file, ~cil, ~goblint, ~warnings, ~meta, ~stats, ~file_loc, ()),
+    )};
 
   let fetch_file =
     HttpClient.on_get(res => {
@@ -63,6 +82,7 @@ let make = (~cil, ~goblint, ~warnings, ~meta, ~stats, ~file_loc) => {
         dispatch
         search={state.search}
         cil={state.cil}
+        mainFiles
       />
     </div>
     <div className="col-6 d-flex flex-column h-100">

--- a/src/state/gvDisplay.ml
+++ b/src/state/gvDisplay.ml
@@ -1,10 +1,12 @@
 open Batteries
 open GoblintCil
 
-module File = struct
-  type t = { path : string; contents : string option }
+type fmode = C | CIL
 
-  let make ~path ?contents () = { path; contents }
+module File = struct
+  type t = { path : string; contents : string option; cil : string option; mode : fmode }
+
+  let make ~path ~mode ?contents ?cil () = { path; mode; contents; cil; }
 end
 
 module Func = struct
@@ -27,7 +29,7 @@ type func = Func.t
 
 type t = File of file | Func of func
 
-let file ~path ?contents () = File (File.make ~path ?contents ()) (* TODO: contents argument never used *)
+let file ~path ?(mode=C) ?contents ?cil () = File (File.make ~path ~mode ?contents ?cil ()) (* TODO: contents argument never used *)
 
 (* TODO: unused *)
 let func ~name ~file ?dot () = Func (Func.make ~name ~file ?dot ())

--- a/src/state/gvDisplayReducer.ml
+++ b/src/state/gvDisplayReducer.ml
@@ -1,9 +1,23 @@
 open Batteries
+open GoblintCil
 module D = GvDisplay
 
 let reduce (s : State.t) (d : D.t option) = function
   | `DisplayNothing -> None
   | `DisplayFile path -> Some (D.file ~path ())
+  | `SwitchToCil (file : D.file) ->
+      if(Option.is_none file.cil) then (
+        let global_to_string g = Pretty.sprint ~width:100 (printGlobal defaultCilPrinter () g) in
+        let cil = foldGlobals s.cil (fun acc g ->
+          if(String.equal file.path (get_globalLoc g).file) then
+            acc ^ global_to_string g
+          else
+            acc) "" in
+        Some (D.File {file with D.File.mode = CIL; D.File.cil = Some(cil)})
+      ) else (
+        Some (D.File {file with D.File.mode = CIL})
+      )
+  | `SwitchToC file -> Some (D.File {file with D.File.mode = C})
   | `DisplayFunc (name, file) ->
       let f = D.Func.make ~name ~file () in
       let fd = D.Func.fundec f s.cil in

--- a/src/state/gvInspect.ml
+++ b/src/state/gvInspect.ml
@@ -1,7 +1,7 @@
 module Line = struct
   type t = string * int
 
-  let of_location (loc : GoblintCil.location) = (loc.file, loc.line)
+  let of_location (loc : GoblintCil.location) = Some (loc.file, loc.line)
 end
 
 module Node = struct

--- a/src/state/gvInspectReducer.ml
+++ b/src/state/gvInspectReducer.ml
@@ -2,5 +2,7 @@ open Batteries
 module I = GvInspect
 
 let reduce (_ : State.t) (_ : I.t option) = function
-  | `InspectLine (file, num) -> I.line file num |> Option.some
-  | `InspectNode id -> I.node id |> Option.some
+  | `InspectLine (Some (file, num)) -> I.line file num |> Option.some
+  | `InspectLine None -> None
+  | `InspectNode (Some id) -> I.node id |> Option.some
+  | `InspectNode None -> None

--- a/src/state/reducer.ml
+++ b/src/state/reducer.ml
@@ -2,7 +2,7 @@ let reducer (s : State.t) = function
   | `SwitchSidebarLeft selected_sidebar_left -> { s with selected_sidebar_left }
   | `SwitchSidebarRight selected_sidebar_right -> { s with selected_sidebar_right }
   | `SwitchPanel selected_panel -> { s with selected_panel }
-  | (`DisplayNothing | `DisplayFile _ | `DisplayFunc _ | `UpdateFileContents _ | `UpdateFuncDot _)
+  | (`DisplayNothing | `DisplayFile _ | `SwitchToC _ | `SwitchToCil _ | `DisplayFunc _ | `UpdateFileContents _ | `UpdateFuncDot _)
     as a ->
       { s with display = GvDisplayReducer.reduce s s.display a }
   | (`InspectLine _ | `InspectNode _) as a ->

--- a/src/state/state.ml
+++ b/src/state/state.ml
@@ -56,5 +56,5 @@ let default =
     search = Search.default;
   }
 
-let make ~cil ~goblint ~warnings ~meta ~stats ~file_loc () =
-  { default with cil; goblint; warnings; meta; stats; file_loc }
+let make ~file ~cil ~goblint ~warnings ~meta ~stats ~file_loc () =
+  { default with display=Some(File(file)); cil; goblint; warnings; meta; stats; file_loc }

--- a/src/ui/content/gvBreadcrumb.re
+++ b/src/ui/content/gvBreadcrumb.re
@@ -2,7 +2,10 @@ open React.Dom.Dsl.Html;
 open Batteries;
 
 let make_breadcrumb_items = (display: State.display, dispatch) => {
-  let on_click = (f : GvDisplay.func, _) => dispatch @@ `DisplayFile(f.file);
+  let on_click = (f : GvDisplay.func, _) => {
+    dispatch @@ `InspectLine(None);
+    dispatch @@ `DisplayFile(f.file)
+  };
 
   <>
     {switch (display) {

--- a/src/ui/content/gvBreadcrumb.re
+++ b/src/ui/content/gvBreadcrumb.re
@@ -2,19 +2,43 @@ open React.Dom.Dsl.Html;
 open Batteries;
 
 let make_breadcrumb_items = (display: State.display, dispatch) => {
-  let on_click = (f : GvDisplay.func, _) => {
+  let on_click_func = (f : GvDisplay.func, _) => {
     dispatch @@ `InspectLine(None);
     dispatch @@ `DisplayFile(f.file)
+  };
+  let on_click_file = (f : GvDisplay.file, _) => {
+    if(f.mode == GvDisplay.CIL) {
+      dispatch @@ `SwitchToC(f)
+      dispatch @@ `InspectLine(None);
+    }
+  };
+  let on_click_cil = (f : GvDisplay.file, _) => {
+    if(f.mode == GvDisplay.C) {
+      dispatch @@ `SwitchToCil(f);
+      dispatch @@ `InspectLine(None);
+    }
   };
 
   <>
     {switch (display) {
-     | File(f) =>
-       <li className="breadcrumb-item active"> {f.path |> React.string} </li>
+    | File(f) =>
+      let disButton = "btn btn-secondary btn-sm disabled";
+      let actButton = "btn btn-outline-primary btn-sm";
+      <div className="d-flex justify-content-between w-100">
+        <li className="breadcrumb-item active pt-1"> {f.path |> React.string} </li>
+        <div className="btn-group btn-group-toggle">
+          <label className={(f.mode==GvDisplay.C)?disButton:actButton} onClick=on_click_file(f)>
+            {"C File" |> React.string}
+          </label>
+          <label className={(f.mode==GvDisplay.CIL)?disButton:actButton} onClick=on_click_cil(f)>
+            {"CIL" |> React.string}
+          </label>
+        </div>
+      </div>
      | Func(f) =>
        <>
          <li className="breadcrumb-item">
-           <Link on_click={on_click(f)}>
+           <Link on_click={on_click_func(f)}>
              ...{f.file |> React.string}
            </Link>
          </li>

--- a/src/ui/content/gvFileView.re
+++ b/src/ui/content/gvFileView.re
@@ -30,7 +30,7 @@ let make_inspect_link = (goblint, file: GvDisplay.file, dispatch, line) =>
     span##.textContent := "Inspect" |> Js.string |> Js.Opt.return;
     span##.onclick :=
       Dom.handler(_ => {
-        dispatch(`InspectLine((file.path, line)));
+        dispatch(`InspectLine(Some((file.path, line))));
         Js._false;
       });
 

--- a/src/ui/content/gvFuncView.re
+++ b/src/ui/content/gvFuncView.re
@@ -4,7 +4,7 @@ open Js_of_ocaml;
 [@react.component]
 let make = (~func: GvDisplay.func, ~dispatch) => {
   let show_info = id => {
-    dispatch @@ `InspectNode(id |> Js.to_string);
+    dispatch @@ `InspectNode(id |> Js.to_string |> Option.some);
     // When you click on a link like `javascript:show_info('42')` in Firefox, it
     // replaces the contents of the current page with the return value of
     // `show_info('42')`. Therefore, this function must explicitly return

--- a/src/ui/panel/WarningView.re
+++ b/src/ui/panel/WarningView.re
@@ -16,9 +16,10 @@ let make = (~warnings, ~dispatch) =>
             |> List.mapi((i, (text, loc, alert)) => {
                   let onClick =
                     loc
-                    |> Option.map((loc, _) =>
+                    |> Option.map((loc : GoblintCil.location, _) => {
+                        dispatch @@ `DisplayFile(loc.file);
                         dispatch @@ `InspectLine(GvInspect.Line.of_location(loc))
-                      );
+                  });
                   <li className={"link-like alert " ++ alert} key={string_of_int(i)} ?onClick>
                     {text |> React.string}
                   </li>;

--- a/src/ui/sidebar/SidebarLeft.re
+++ b/src/ui/sidebar/SidebarLeft.re
@@ -24,7 +24,7 @@ let make_tabs = (active, dispatch) => {
 };
 
 [@react.component]
-let make = (~active, ~dispatch, ~search, ~cil) => {
+let make = (~active, ~dispatch, ~search, ~cil, ~mainFiles) => {
   <div className="sidebar-left">
     <ul className="nav nav-tabs">
     ...{make_tabs(active, dispatch)}
@@ -32,7 +32,7 @@ let make = (~active, ~dispatch, ~search, ~cil) => {
     <div className="tab-content">
       <div className="tab-pane active">
         {switch (active) {
-         | Files => <GvFileList cil dispatch />
+         | Files => <GvFileList cil dispatch mainFiles/>
          | Search => <SearchView search dispatch />
          | _ => <div/>
          }}

--- a/src/ui/sidebar/fileList/fileEntry.re
+++ b/src/ui/sidebar/fileList/fileEntry.re
@@ -3,7 +3,10 @@ open Html;
 open Batteries;
 
 let make_func_list = (file, funcs, dispatch) => {
-  let on_click = (func, file, _) => dispatch @@ `DisplayFunc((func, file));
+  let on_click = (func, file, _) => {
+    dispatch @@ `InspectNode(None);
+    dispatch @@ `DisplayFunc((func, file))
+  };
 
   funcs
   |> List.map(func => {
@@ -18,7 +21,10 @@ let make_func_list = (file, funcs, dispatch) => {
 };
 [@react.component]
 let make = (~path, ~name, ~dispatch, ~functions, ~collapsed) => {
-  let on_click = (file, _) => dispatch @@ `DisplayFile(file);
+  let on_click = (file, _) => {
+    dispatch @@ `InspectLine(None);
+    dispatch @@ `DisplayFile(file)
+  };
   let make_title = name =>
     <Link on_click={on_click(path)} class_=["text-link"]>
       ...{name |> React.string}

--- a/src/ui/sidebar/fileList/gvFileList.re
+++ b/src/ui/sidebar/fileList/gvFileList.re
@@ -32,22 +32,15 @@ let rec make_entries = (prefix, files, tree, mainFiles, dispatch) => {
 };
 
 [@react.component]
-let make = (~cil: Cil.file, ~dispatch) => {
+let make = (~cil: Cil.file, ~dispatch, ~mainFiles) => {
   let files = Hashtbl.create(64);
-  let (mf,_,_) = Goblint_lib.Cilfacade.getFuns(cil);
-  let mainFiles = Cil.foldGlobals(
+  Cil.iterGlobals(
     cil,
-    (mainFiles, g) =>
+    (g) =>
     switch(g) {
-    | GFun(fdec, loc) => Hashtbl.add(files, loc.file, fdec.svar.vname);
-      if(List.mem(fdec, mf)) {
-        [loc.file, ...mainFiles]
-      } else {
-        mainFiles
-      };
-    | _ => mainFiles
+    | GFun(fdec, loc) => Hashtbl.add(files, loc.file, fdec.svar.vname)
+    | _ => ()
     },
-    [],
   );
 
   let tree = files |> Hashtbl.keys |> List.of_enum |> FileTree.mk_tree;


### PR DESCRIPTION
This PR implements that
- the file view switches to the correct file when clicking on a warning. Previously the line of the warning location was highlighted in whichever file was currently open. This could lead to the correct line number being highlighted in the wrong file.
- the highlighting of lines and showing some abstract state is reset to none whenever one chooses a different file or cfg to be displayed.
- in addition, the first file containing a start function is displayed initially