### PR TITLE
Bump OCaml lower bound to 4.14

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
  (synopsis "Web frontend for Goblint")
  (depends
   dune
-  (ocaml (>= 4.10.0))
+  (ocaml (>= 4.14.0))
   reason
   batteries
   cohttp-lwt

--- a/gobview.opam
+++ b/gobview.opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/goblint/gobview"
 bug-reports: "https://github.com/goblint/gobview/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.14.0"}
   "reason"
   "batteries"
   "cohttp-lwt"


### PR DESCRIPTION
In synchronization with https://github.com/goblint/analyzer/pull/1448.