### PR TITLE
Try to fix unhandled node scheme errors

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
     mode: process.env.NODE_ENV ? process.env.NODE_ENV : 'development',
@@ -24,8 +25,11 @@ module.exports = {
             },
         ],
     },
-    plugins: [new HtmlWebpackPlugin({ template: 'public/index.html' })],
-    resolve: { fallback: { child_process: false, constants: false, fs: false, tty: false } },
+    plugins: [
+        new HtmlWebpackPlugin({ template: 'public/index.html' }),
+        new webpack.IgnorePlugin({ resourceRegExp: /^node:/ }),
+    ],
+    resolve: { fallback: { child_process: false, constants: false, fs: false, tty: false, 'node:constants': false, 'node:child_process': false, 'node:fs': false, 'node:tty': false } },
     devServer: {
         contentBase: path.resolve(__dirname, 'public'),
     },


### PR DESCRIPTION
Fixes the following errors which break compilation for some reason:

```
ERROR in node:child_process
Module build failed: UnhandledSchemeError: Reading from "node:child_process" is not handled by plugins (Unhandled scheme). Webpack supports "data:" and "file:" URIs by default. You may need an additional plugin to handle "node:" URIs.
    at /home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:767:26
    at Hook.eval [as callAsync] (eval at create (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Object.processResource (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:764:9)
    at processResource (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:220:11)
    at iteratePitchingLoaders (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:171:10)
    at runLoaders (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:397:2)
    at NormalModule.doBuild (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:754:3)
    at NormalModule.build (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:908:15)
    at /home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/Compilation.js:1318:12
    at NormalModule.needBuild (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:1177:32)
 @ ./src/App.bc.js 1269:2-31

ERROR in node:constants
Module build failed: UnhandledSchemeError: Reading from "node:constants" is not handled by plugins (Unhandled scheme). Webpack supports "data:" and "file:" URIs by default. You may need an additional plugin to handle "node:" URIs.
    at /home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:767:26
    at Hook.eval [as callAsync] (eval at create (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/tapable/lib/Hook.js:18:14)
    at Object.processResource (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:764:9)
    at processResource (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:220:11)
    at iteratePitchingLoaders (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:171:10)
    at runLoaders (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:397:2)
    at NormalModule.doBuild (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:754:3)
    at NormalModule.build (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:908:15)
    at /home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/Compilation.js:1318:12
 @ ./src/App.bc.js 580:2-27

ERROR in node:tty
Module build failed: UnhandledSchemeError: Reading from "node:tty" is not handled by plugins (Unhandled scheme). Webpack supports "data:" and "file:" URIs by default. You may need an additional plugin to handle "node:" URIs.
    at /home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:767:26
    at Hook.eval [as callAsync] (eval at create (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Object.processResource (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:764:9)
    at processResource (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:220:11)
    at iteratePitchingLoaders (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:171:10)
    at runLoaders (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/loader-runner/lib/LoaderRunner.js:397:2)
    at NormalModule.doBuild (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:754:3)
    at NormalModule.build (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:908:15)
    at /home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/Compilation.js:1318:12
    at NormalModule.needBuild (/home/simmo/dev/goblint/sv-comp/goblint/_build/default/gobview/node_modules/webpack/lib/NormalModule.js:1177:32)
 @ ./src/App.bc.js 1284:2-21
```

These are suggestions from Copilot.
I have no clue why these are suddenly necessary.